### PR TITLE
docs: fix deprecation warning

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,8 +65,9 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format # Footnotes
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
+  # Footnotes
   - footnotes
 
   # Keys
@@ -74,9 +75,10 @@ markdown_extensions:
 
   # Icons & emojis
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg # Images
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
+  # Images
   - attr_list
   - md_in_html
 


### PR DESCRIPTION
### Summary of Changes

Handle deprecation of `mkdocs_material_extensions`.