### PR TITLE
fix: race condition when initializing multiprocessing manager

### DIFF
--- a/src/safeds_runner/server/pipeline_manager.py
+++ b/src/safeds_runner/server/pipeline_manager.py
@@ -41,6 +41,7 @@ class PipelineManager:
 
     @cached_property
     def _multiprocessing_manager(self) -> SyncManager:
+        multiprocessing.set_start_method('spawn')
         return multiprocessing.Manager()
 
     @cached_property

--- a/src/safeds_runner/server/pipeline_manager.py
+++ b/src/safeds_runner/server/pipeline_manager.py
@@ -42,7 +42,7 @@ class PipelineManager:
     @cached_property
     def _multiprocessing_manager(self) -> SyncManager:
         if multiprocessing.get_start_method() != "spawn":
-            multiprocessing.set_start_method("spawn", True)
+            multiprocessing.set_start_method("spawn", force=True)
         return multiprocessing.Manager()
 
     @cached_property
@@ -67,6 +67,7 @@ class PipelineManager:
 
         This method should not be called during the bootstrap phase of the python interpreter, as it leads to a crash.
         """
+        _mq = self._messages_queue  # Initialize it here before starting a thread to avoid potential race condition
         if not self._messages_queue_thread.is_alive():
             self._messages_queue_thread.start()
 

--- a/src/safeds_runner/server/pipeline_manager.py
+++ b/src/safeds_runner/server/pipeline_manager.py
@@ -35,13 +35,14 @@ class PipelineManager:
     """
 
     def __init__(self) -> None:
-        """Create a new PipelineManager object, which needs to be started by calling startup()."""
+        """Create a new PipelineManager object, which is lazily started, when needed."""
         self._placeholder_map: dict = {}
         self._websocket_target: simple_websocket.Server | None = None
 
     @cached_property
     def _multiprocessing_manager(self) -> SyncManager:
-        multiprocessing.set_start_method('spawn')
+        if multiprocessing.get_start_method() != 'spawn':
+            multiprocessing.set_start_method('spawn', True)
         return multiprocessing.Manager()
 
     @cached_property

--- a/tests/safeds_runner/server/test_runner_main.py
+++ b/tests/safeds_runner/server/test_runner_main.py
@@ -7,6 +7,7 @@ _project_root: Path = Path(__file__).parent / ".." / ".." / ".."
 
 
 def test_should_runner_start_successfully() -> None:
+    subprocess._USE_VFORK = False  # Do not fork the subprocess as it is unsafe to do
     process = subprocess.Popen(["poetry", "run", "safe-ds-runner", "start"], cwd=_project_root, stderr=subprocess.PIPE)
     while process.poll() is None:
         process_line = str(typing.cast(IO[bytes], process.stderr).readline(), "utf-8").strip()

--- a/tests/safeds_runner/server/test_websocket_mock.py
+++ b/tests/safeds_runner/server/test_websocket_mock.py
@@ -44,7 +44,7 @@ class MockWebsocketConnection:
             with self.condition_variable:
                 if len(self.received) >= wait_for_messages:
                     return
-                self.condition_variable.wait()
+                self.condition_variable.wait(1.0)  # this should not be needed, but it seems the process can get stuck
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #18

### Summary of Changes

- use spawn instead of fork to not deadlock when running tests
