### PR TITLE
ci: exclude test files from Codecov report

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "tests/**/*"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "tests/**/*"
+  - 'tests/**/*'


### PR DESCRIPTION
### Summary of Changes

For some reason, Codecov started to treat some test files as source files. This PR explicitly excludes all test files.
