### PR TITLE
fix: allow multiple connections to work with the runner

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1812,6 +1812,20 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.2.0"
+description = "pytest plugin to abort hanging tests"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-timeout-2.2.0.tar.gz", hash = "sha256:3b0b95dabf3cb50bac9ef5ca912fa0cfc286526af17afc806824df20c2f72c90"},
+    {file = "pytest_timeout-2.2.0-py3-none-any.whl", hash = "sha256:bde531e096466f49398a59f2dde76fa78429a09a12411466f88a07213e220de2"},
+]
+
+[package.dependencies]
+pytest = ">=5.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -2630,4 +2644,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11,<3.13"
-content-hash = "d3feaaef7a0261fb0a4bf92e3f1a40f7e0157a6e2b4490983f1671abcc4e4a64"
+content-hash = "479e3309100d29236d5ee5d94bfe98a9da070d71997a2beec33ebc3a99e8c792"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ gevent = "^23.9.1"
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.3"
 pytest-cov = "^4.1.0"
+pytest-timeout = "^2.2.0"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.4.3"

--- a/src/safeds_runner/server/main.py
+++ b/src/safeds_runner/server/main.py
@@ -186,8 +186,12 @@ def start_server(port: int) -> None:  # pragma: no cover
     builtins.print = functools.partial(print, flush=True)  # type: ignore[assignment]
 
     logging.getLogger().setLevel(logging.DEBUG)
+    # Startup early, so our multiprocessing setup works
+    app_pipeline_manager.startup()
     from gevent.pywsgi import WSGIServer
-
+    from gevent.monkey import patch_all
+    # Patch WebSockets to work in parallel
+    patch_all()
     logging.info("Starting Safe-DS Runner on port %s", str(port))
     # Only bind to host=127.0.0.1. Connections from other devices should not be accepted
-    WSGIServer(("127.0.0.1", port), app).serve_forever()
+    WSGIServer(("127.0.0.1", port), app, spawn=8).serve_forever()

--- a/src/safeds_runner/server/pipeline_manager.py
+++ b/src/safeds_runner/server/pipeline_manager.py
@@ -87,7 +87,7 @@ class PipelineManager:
         except BaseException as error:  # noqa: BLE001  # pragma: no cover
             logging.warning("Message queue terminated: %s", error.__repr__())  # pragma: no cover
 
-    def set_new_websocket_target(self, websocket_connection: simple_websocket.Server) -> None:
+    def connect(self, websocket_connection: simple_websocket.Server) -> None:
         """
         Add a websocket connection to relay event messages to, which are occurring during pipeline execution.
 
@@ -98,7 +98,7 @@ class PipelineManager:
         """
         self._websocket_target.append(websocket_connection)
 
-    def remove_websocket_target(self, websocket_connection: simple_websocket.Server) -> None:
+    def disconnect(self, websocket_connection: simple_websocket.Server) -> None:
         """
         Remove a websocket target connection to no longer receive messages.
 

--- a/src/safeds_runner/server/pipeline_manager.py
+++ b/src/safeds_runner/server/pipeline_manager.py
@@ -81,7 +81,8 @@ class PipelineManager:
             while self._messages_queue is not None:
                 message = self._messages_queue.get()
                 message_encoded = json.dumps(message.to_dict())
-                for connection in self._websocket_target:
+                # only send messages to the same connection once
+                for connection in set(self._websocket_target):
                     connection.send(message_encoded)
         except BaseException as error:  # noqa: BLE001  # pragma: no cover
             logging.warning("Message queue terminated: %s", error.__repr__())  # pragma: no cover

--- a/src/safeds_runner/server/pipeline_manager.py
+++ b/src/safeds_runner/server/pipeline_manager.py
@@ -56,7 +56,7 @@ class PipelineManager:
             daemon=True,
         )
 
-    def _startup(self) -> None:
+    def startup(self) -> None:
         """
         Prepare the runner for running Safe-DS pipelines.
 
@@ -111,7 +111,7 @@ class PipelineManager:
         execution_id : str
             Unique ID to identify this execution.
         """
-        self._startup()
+        self.startup()
         if execution_id not in self._placeholder_map:
             self._placeholder_map[execution_id] = self._multiprocessing_manager.dict()
         process = PipelineProcess(

--- a/tests/safeds_runner/server/test_websocket_mock.py
+++ b/tests/safeds_runner/server/test_websocket_mock.py
@@ -6,9 +6,8 @@ import sys
 import threading
 
 import pytest
-import simple_websocket
-
 import safeds_runner.server.main
+import simple_websocket
 from safeds_runner.server.main import app_pipeline_manager, ws_main
 from safeds_runner.server.messages import (
     Message,
@@ -69,87 +68,86 @@ class MockWebsocketConnection:
         (json.dumps({"type": "program", "id": "1234", "data": "a"}), "Message data is not a JSON object"),
         (json.dumps({"type": "placeholder_query", "id": "123", "data": {"a": "v"}}), "Message data is not a string"),
         (
-                json.dumps({
-                    "type": "program",
-                    "id": "1234",
-                    "data": {"main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
-                }),
-                "No 'code' parameter given",
+            json.dumps({
+                "type": "program",
+                "id": "1234",
+                "data": {"main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
+            }),
+            "No 'code' parameter given",
         ),
         (
-                json.dumps({"type": "program", "id": "1234", "data": {"code": {"": {"entry": ""}}}}),
-                "No 'main' parameter given",
+            json.dumps({"type": "program", "id": "1234", "data": {"code": {"": {"entry": ""}}}}),
+            "No 'main' parameter given",
         ),
         (
-                json.dumps({
-                    "type": "program",
-                    "id": "1234",
-                    "data": {"code": {"": {"entry": ""}}, "main": {"modulepath": "1", "module": "2"}},
-                }),
-                "Invalid 'main' parameter given",
+            json.dumps({
+                "type": "program",
+                "id": "1234",
+                "data": {"code": {"": {"entry": ""}}, "main": {"modulepath": "1", "module": "2"}},
+            }),
+            "Invalid 'main' parameter given",
         ),
         (
-                json.dumps({
-                    "type": "program",
-                    "id": "1234",
-                    "data": {"code": {"": {"entry": ""}}, "main": {"modulepath": "1", "pipeline": "3"}},
-                }),
-                "Invalid 'main' parameter given",
+            json.dumps({
+                "type": "program",
+                "id": "1234",
+                "data": {"code": {"": {"entry": ""}}, "main": {"modulepath": "1", "pipeline": "3"}},
+            }),
+            "Invalid 'main' parameter given",
         ),
         (
-                json.dumps({
-                    "type": "program",
-                    "id": "1234",
-                    "data": {"code": {"": {"entry": ""}}, "main": {"module": "2", "pipeline": "3"}},
-                }),
-                "Invalid 'main' parameter given",
+            json.dumps({
+                "type": "program",
+                "id": "1234",
+                "data": {"code": {"": {"entry": ""}}, "main": {"module": "2", "pipeline": "3"}},
+            }),
+            "Invalid 'main' parameter given",
         ),
         (
-                json.dumps({
-                    "type": "program",
-                    "id": "1234",
-                    "data": {
-                        "code": {"": {"entry": ""}},
-                        "main": {"modulepath": "1", "module": "2", "pipeline": "3", "other": "4"},
-                    },
-                }),
-                "Invalid 'main' parameter given",
+            json.dumps({
+                "type": "program",
+                "id": "1234",
+                "data": {
+                    "code": {"": {"entry": ""}},
+                    "main": {"modulepath": "1", "module": "2", "pipeline": "3", "other": "4"},
+                },
+            }),
+            "Invalid 'main' parameter given",
         ),
         (
-                json.dumps({
-                    "type": "program",
-                    "id": "1234",
-                    "data": {
-                        "code": {"": {"entry": ""}},
-                        "main": {"modulepath": "1", "module": "2", "pipeline": "3", "other": {"4": "a"}},
-                    },
-                }),
-                "Invalid 'main' parameter given",
+            json.dumps({
+                "type": "program",
+                "id": "1234",
+                "data": {
+                    "code": {"": {"entry": ""}},
+                    "main": {"modulepath": "1", "module": "2", "pipeline": "3", "other": {"4": "a"}},
+                },
+            }),
+            "Invalid 'main' parameter given",
         ),
         (
-                json.dumps({
-                    "type": "program",
-                    "id": "1234",
-                    "data": {"code": "a", "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
-                }),
-                "Invalid 'code' parameter given",
+            json.dumps({
+                "type": "program",
+                "id": "1234",
+                "data": {"code": "a", "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
+            }),
+            "Invalid 'code' parameter given",
         ),
         (
-                json.dumps({
-                    "type": "program",
-                    "id": "1234",
-                    "data": {"code": {"": "a"}, "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
-                }),
-                "Invalid 'code' parameter given",
+            json.dumps({
+                "type": "program",
+                "id": "1234",
+                "data": {"code": {"": "a"}, "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
+            }),
+            "Invalid 'code' parameter given",
         ),
         (
-                json.dumps({
-                    "type": "program",
-                    "id": "1234",
-                    "data": {"code": {"": {"a": {"b": "c"}}},
-                             "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
-                }),
-                "Invalid 'code' parameter given",
+            json.dumps({
+                "type": "program",
+                "id": "1234",
+                "data": {"code": {"": {"a": {"b": "c"}}}, "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
+            }),
+            "Invalid 'code' parameter given",
         ),
     ],
     ids=[
@@ -183,39 +181,39 @@ def test_should_fail_message_validation(websocket_message: str, exception_messag
 @pytest.mark.skipif(
     sys.platform.startswith("win") and os.getenv("COVERAGE_RCFILE") is not None,
     reason=(
-            "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
-            "causes Manager to hang, when using multiprocessing coverage"
+        "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
+        "causes Manager to hang, when using multiprocessing coverage"
     ),
 )
 @pytest.mark.parametrize(
     argnames="messages,expected_response_runtime_error",
     argvalues=[
         (
-                [
-                    json.dumps({
-                        "type": "program",
-                        "id": "abcdefgh",
-                        "data": {
-                            "code": {
-                                "": {
-                                    "gen_test_a": "def pipe():\n\traise Exception('Test Exception')\n",
-                                    "gen_test_a_pipe": (
-                                            "from gen_test_a import pipe\n\nif __name__ == '__main__':\n\tpipe()"
-                                    ),
-                                },
+            [
+                json.dumps({
+                    "type": "program",
+                    "id": "abcdefgh",
+                    "data": {
+                        "code": {
+                            "": {
+                                "gen_test_a": "def pipe():\n\traise Exception('Test Exception')\n",
+                                "gen_test_a_pipe": (
+                                    "from gen_test_a import pipe\n\nif __name__ == '__main__':\n\tpipe()"
+                                ),
                             },
-                            "main": {"modulepath": "", "module": "test_a", "pipeline": "pipe"},
                         },
-                    }),
-                ],
-                Message(message_type_runtime_error, "abcdefgh", {"message": "Test Exception"}),
+                        "main": {"modulepath": "", "module": "test_a", "pipeline": "pipe"},
+                    },
+                }),
+            ],
+            Message(message_type_runtime_error, "abcdefgh", {"message": "Test Exception"}),
         ),
     ],
     ids=["raise_exception"],
 )
 def test_should_execute_pipeline_return_exception(
-        messages: list[str],
-        expected_response_runtime_error: Message,
+    messages: list[str],
+    expected_response_runtime_error: Message,
 ) -> None:
     mock_connection = MockWebsocketConnection(messages)
     app_pipeline_manager.set_new_websocket_target(mock_connection)
@@ -239,71 +237,71 @@ def test_should_execute_pipeline_return_exception(
 @pytest.mark.skipif(
     sys.platform.startswith("win") and os.getenv("COVERAGE_RCFILE") is not None,
     reason=(
-            "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
-            "causes Manager to hang, when using multiprocessing coverage"
+        "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
+        "causes Manager to hang, when using multiprocessing coverage"
     ),
 )
 @pytest.mark.parametrize(
     argnames="initial_messages,initial_execution_message_wait,appended_messages,expected_responses",
     argvalues=[
         (
-                [
-                    json.dumps({
-                        "type": "program",
-                        "id": "abcdefg",
-                        "data": {
-                            "code": {
-                                "": {
-                                    "gen_test_a": (
-                                            "import safeds_runner.server.pipeline_manager\n\ndef pipe():\n\tvalue1 ="
-                                            " 1\n\tsafeds_runner.server.pipeline_manager.runner_save_placeholder('value1',"
-                                            " value1)\n\tsafeds_runner.server.pipeline_manager.runner_save_placeholder('obj',"
-                                            " object())\n"
-                                    ),
-                                    "gen_test_a_pipe": (
-                                            "from gen_test_a import pipe\n\nif __name__ == '__main__':\n\tpipe()"
-                                    ),
-                                },
+            [
+                json.dumps({
+                    "type": "program",
+                    "id": "abcdefg",
+                    "data": {
+                        "code": {
+                            "": {
+                                "gen_test_a": (
+                                    "import safeds_runner.server.pipeline_manager\n\ndef pipe():\n\tvalue1 ="
+                                    " 1\n\tsafeds_runner.server.pipeline_manager.runner_save_placeholder('value1',"
+                                    " value1)\n\tsafeds_runner.server.pipeline_manager.runner_save_placeholder('obj',"
+                                    " object())\n"
+                                ),
+                                "gen_test_a_pipe": (
+                                    "from gen_test_a import pipe\n\nif __name__ == '__main__':\n\tpipe()"
+                                ),
                             },
-                            "main": {"modulepath": "", "module": "test_a", "pipeline": "pipe"},
                         },
-                    }),
-                ],
-                2,
-                [
-                    # Query Placeholder
-                    json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "value1"}),
-                    # Query not displayable Placeholder
-                    json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "obj"}),
-                    # Query invalid placeholder
-                    json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "value2"}),
-                ],
-                [
-                    # Validate Placeholder Information
-                    Message(message_type_placeholder_type, "abcdefg", create_placeholder_description("value1", "Int")),
-                    Message(message_type_placeholder_type, "abcdefg", create_placeholder_description("obj", "object")),
-                    # Validate Progress Information
-                    Message(message_type_runtime_progress, "abcdefg", create_runtime_progress_done()),
-                    # Query Result Valid
-                    Message(message_type_placeholder_value, "abcdefg", create_placeholder_value("value1", "Int", 1)),
-                    # Query Result not displayable
-                    Message(
-                        message_type_placeholder_value,
-                        "abcdefg",
-                        create_placeholder_value("obj", "object", "<Not displayable>"),
-                    ),
-                    # Query Result Invalid
-                    Message(message_type_placeholder_value, "abcdefg", create_placeholder_value("value2", "", "")),
-                ],
+                        "main": {"modulepath": "", "module": "test_a", "pipeline": "pipe"},
+                    },
+                }),
+            ],
+            2,
+            [
+                # Query Placeholder
+                json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "value1"}),
+                # Query not displayable Placeholder
+                json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "obj"}),
+                # Query invalid placeholder
+                json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "value2"}),
+            ],
+            [
+                # Validate Placeholder Information
+                Message(message_type_placeholder_type, "abcdefg", create_placeholder_description("value1", "Int")),
+                Message(message_type_placeholder_type, "abcdefg", create_placeholder_description("obj", "object")),
+                # Validate Progress Information
+                Message(message_type_runtime_progress, "abcdefg", create_runtime_progress_done()),
+                # Query Result Valid
+                Message(message_type_placeholder_value, "abcdefg", create_placeholder_value("value1", "Int", 1)),
+                # Query Result not displayable
+                Message(
+                    message_type_placeholder_value,
+                    "abcdefg",
+                    create_placeholder_value("obj", "object", "<Not displayable>"),
+                ),
+                # Query Result Invalid
+                Message(message_type_placeholder_value, "abcdefg", create_placeholder_value("value2", "", "")),
+            ],
         ),
     ],
     ids=["query_valid_query_invalid"],
 )
 def test_should_execute_pipeline_return_valid_placeholder(
-        initial_messages: list[str],
-        initial_execution_message_wait: int,
-        appended_messages: list[str],
-        expected_responses: list[Message],
+    initial_messages: list[str],
+    initial_execution_message_wait: int,
+    appended_messages: list[str],
+    expected_responses: list[Message],
 ) -> None:
     # Initial execution
     mock_connection = MockWebsocketConnection(initial_messages)
@@ -324,58 +322,58 @@ def test_should_execute_pipeline_return_valid_placeholder(
 @pytest.mark.skipif(
     sys.platform.startswith("win") and os.getenv("COVERAGE_RCFILE") is not None,
     reason=(
-            "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
-            "causes Manager to hang, when using multiprocessing coverage"
+        "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
+        "causes Manager to hang, when using multiprocessing coverage"
     ),
 )
 @pytest.mark.parametrize(
     argnames="messages,expected_response",
     argvalues=[
         (
-                [
-                    json.dumps({
-                        "type": "program",
-                        "id": "123456789",
-                        "data": {
-                            "code": {
-                                "": {
-                                    "gen_b": (
-                                            "import safeds_runner.codegen\n"
-                                            "from a.stub import u\n"
-                                            "from v.u.s.testing import add1\n"
-                                            "\n"
-                                            "def c():\n"
-                                            "\ta1 = 1\n"
-                                            "\ta2 = safeds_runner.codegen.eager_or(True, False)\n"
-                                            "\tprint('test2')\n"
-                                            "\tprint('new dynamic output')\n"
-                                            "\tprint(f'Add1: {add1(1, 2)}')\n"
-                                            "\treturn a1 + a2\n"
-                                    ),
-                                    "gen_b_c": "from gen_b import c\n\nif __name__ == '__main__':\n\tc()",
-                                },
-                                "a": {"stub": "def u():\n\treturn 1"},
-                                "v.u.s": {
-                                    "testing": "import a.stub;\n\ndef add1(v1, v2):\n\treturn v1 + v2 + a.stub.u()\n",
-                                },
+            [
+                json.dumps({
+                    "type": "program",
+                    "id": "123456789",
+                    "data": {
+                        "code": {
+                            "": {
+                                "gen_b": (
+                                    "import safeds_runner.codegen\n"
+                                    "from a.stub import u\n"
+                                    "from v.u.s.testing import add1\n"
+                                    "\n"
+                                    "def c():\n"
+                                    "\ta1 = 1\n"
+                                    "\ta2 = safeds_runner.codegen.eager_or(True, False)\n"
+                                    "\tprint('test2')\n"
+                                    "\tprint('new dynamic output')\n"
+                                    "\tprint(f'Add1: {add1(1, 2)}')\n"
+                                    "\treturn a1 + a2\n"
+                                ),
+                                "gen_b_c": "from gen_b import c\n\nif __name__ == '__main__':\n\tc()",
                             },
-                            "main": {"modulepath": "", "module": "b", "pipeline": "c"},
+                            "a": {"stub": "def u():\n\treturn 1"},
+                            "v.u.s": {
+                                "testing": "import a.stub;\n\ndef add1(v1, v2):\n\treturn v1 + v2 + a.stub.u()\n",
+                            },
                         },
-                    }),
-                ],
-                Message(message_type_runtime_progress, "123456789", create_runtime_progress_done()),
+                        "main": {"modulepath": "", "module": "b", "pipeline": "c"},
+                    },
+                }),
+            ],
+            Message(message_type_runtime_progress, "123456789", create_runtime_progress_done()),
         ),
         (
-                # Query Result Invalid (no pipeline exists)
-                [
-                    json.dumps({"type": "invalid_message_type", "id": "unknown-code-id-never-generated", "data": ""}),
-                    json.dumps({"type": "placeholder_query", "id": "unknown-code-id-never-generated", "data": "v"}),
-                ],
-                Message(
-                    message_type_placeholder_value,
-                    "unknown-code-id-never-generated",
-                    create_placeholder_value("v", "", ""),
-                ),
+            # Query Result Invalid (no pipeline exists)
+            [
+                json.dumps({"type": "invalid_message_type", "id": "unknown-code-id-never-generated", "data": ""}),
+                json.dumps({"type": "placeholder_query", "id": "unknown-code-id-never-generated", "data": "v"}),
+            ],
+            Message(
+                message_type_placeholder_value,
+                "unknown-code-id-never-generated",
+                create_placeholder_value("v", "", ""),
+            ),
         ),
     ],
     ids=["progress_message_done", "invalid_message_invalid_placeholder_query"],
@@ -392,8 +390,8 @@ def test_should_successfully_execute_simple_flow(messages: list[str], expected_r
 @pytest.mark.skipif(
     sys.platform.startswith("win") and os.getenv("COVERAGE_RCFILE") is not None,
     reason=(
-            "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
-            "causes Manager to hang, when using multiprocessing coverage"
+        "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
+        "causes Manager to hang, when using multiprocessing coverage"
     ),
 )
 @pytest.mark.parametrize(
@@ -420,13 +418,15 @@ def helper_should_shut_itself_down_run_in_subprocess(sub_messages: list[str]) ->
 helper_should_shut_itself_down_run_in_subprocess.__test__ = False  # type: ignore[attr-defined]
 
 
-@pytest.mark.skip
+@pytest.mark.skip()
 @pytest.mark.timeout(45)
 def test_should_accept_at_least_2_parallel_connections_in_subprocess() -> None:
     port = 6000
     server_output_pipes_stderr_r, server_output_pipes_stderr_w = multiprocessing.Pipe()
-    process = multiprocessing.Process(target=helper_should_accept_at_least_2_parallel_connections_in_subprocess_server,
-                                      args=(port, server_output_pipes_stderr_w))
+    process = multiprocessing.Process(
+        target=helper_should_accept_at_least_2_parallel_connections_in_subprocess_server,
+        args=(port, server_output_pipes_stderr_w),
+    )
     process.start()
     while process.is_alive():
         if not server_output_pipes_stderr_r.poll(0.1):
@@ -452,8 +452,9 @@ def test_should_accept_at_least_2_parallel_connections_in_subprocess() -> None:
     assert connected
 
 
-def helper_should_accept_at_least_2_parallel_connections_in_subprocess_server(port: int,
-                                                                              pipe: multiprocessing.connection.Connection) -> None:
+def helper_should_accept_at_least_2_parallel_connections_in_subprocess_server(
+    port: int, pipe: multiprocessing.connection.Connection,
+) -> None:
     sys.stderr.write = lambda value: pipe.send(value)  # type: ignore[method-assign, assignment]
     sys.stdout.write = lambda value: pipe.send(value)  # type: ignore[method-assign, assignment]
     safeds_runner.server.main.start_server(port)

--- a/tests/safeds_runner/server/test_websocket_mock.py
+++ b/tests/safeds_runner/server/test_websocket_mock.py
@@ -459,4 +459,3 @@ def helper_should_accept_at_least_2_parallel_connections_in_subprocess_server(
     sys.stderr.write = lambda value: pipe.send(value)  # type: ignore[method-assign, assignment]
     sys.stdout.write = lambda value: pipe.send(value)  # type: ignore[method-assign, assignment]
     safeds_runner.server.main.start_server(port)
-

--- a/tests/safeds_runner/server/test_websocket_mock.py
+++ b/tests/safeds_runner/server/test_websocket_mock.py
@@ -416,9 +416,6 @@ def helper_should_shut_itself_down_run_in_subprocess(sub_messages: list[str]) ->
     ws_main(mock_connection, PipelineManager())
 
 
-helper_should_shut_itself_down_run_in_subprocess.__test__ = False  # type: ignore[attr-defined]
-
-
 @pytest.mark.timeout(45)
 def test_should_accept_at_least_2_parallel_connections_in_subprocess() -> None:
     port = 6000
@@ -463,5 +460,3 @@ def helper_should_accept_at_least_2_parallel_connections_in_subprocess_server(
     sys.stdout.write = lambda value: pipe.send(value)  # type: ignore[method-assign, assignment]
     safeds_runner.server.main.start_server(port)
 
-
-helper_should_accept_at_least_2_parallel_connections_in_subprocess_server.__test__ = False  # type: ignore[attr-defined]

--- a/tests/safeds_runner/server/test_websocket_mock.py
+++ b/tests/safeds_runner/server/test_websocket_mock.py
@@ -174,7 +174,7 @@ class MockWebsocketConnection:
 )
 def test_should_fail_message_validation(websocket_message: str, exception_message: str) -> None:
     mock_connection = MockWebsocketConnection([websocket_message])
-    app_pipeline_manager.set_new_websocket_target(mock_connection)
+    app_pipeline_manager.connect(mock_connection)
     ws_main(mock_connection, app_pipeline_manager)
     assert str(mock_connection.close_message) == exception_message
 
@@ -217,7 +217,7 @@ def test_should_execute_pipeline_return_exception(
     expected_response_runtime_error: Message,
 ) -> None:
     mock_connection = MockWebsocketConnection(messages)
-    app_pipeline_manager.set_new_websocket_target(mock_connection)
+    app_pipeline_manager.connect(mock_connection)
     ws_main(mock_connection, app_pipeline_manager)
     mock_connection.wait_for_messages(1)
     exception_message = Message.from_dict(json.loads(mock_connection.get_next_received_message()))
@@ -306,7 +306,7 @@ def test_should_execute_pipeline_return_valid_placeholder(
 ) -> None:
     # Initial execution
     mock_connection = MockWebsocketConnection(initial_messages)
-    app_pipeline_manager.set_new_websocket_target(mock_connection)
+    app_pipeline_manager.connect(mock_connection)
     ws_main(mock_connection, app_pipeline_manager)
     # Wait for at least enough messages to successfully execute pipeline
     mock_connection.wait_for_messages(initial_execution_message_wait)
@@ -381,7 +381,7 @@ def test_should_execute_pipeline_return_valid_placeholder(
 )
 def test_should_successfully_execute_simple_flow(messages: list[str], expected_response: Message) -> None:
     mock_connection = MockWebsocketConnection(messages)
-    app_pipeline_manager.set_new_websocket_target(mock_connection)
+    app_pipeline_manager.connect(mock_connection)
     ws_main(mock_connection, app_pipeline_manager)
     mock_connection.wait_for_messages(1)
     query_result_invalid = Message.from_dict(json.loads(mock_connection.get_next_received_message()))

--- a/tests/safeds_runner/server/test_websocket_mock.py
+++ b/tests/safeds_runner/server/test_websocket_mock.py
@@ -69,86 +69,87 @@ class MockWebsocketConnection:
         (json.dumps({"type": "program", "id": "1234", "data": "a"}), "Message data is not a JSON object"),
         (json.dumps({"type": "placeholder_query", "id": "123", "data": {"a": "v"}}), "Message data is not a string"),
         (
-            json.dumps({
-                "type": "program",
-                "id": "1234",
-                "data": {"main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
-            }),
-            "No 'code' parameter given",
+                json.dumps({
+                    "type": "program",
+                    "id": "1234",
+                    "data": {"main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
+                }),
+                "No 'code' parameter given",
         ),
         (
-            json.dumps({"type": "program", "id": "1234", "data": {"code": {"": {"entry": ""}}}}),
-            "No 'main' parameter given",
+                json.dumps({"type": "program", "id": "1234", "data": {"code": {"": {"entry": ""}}}}),
+                "No 'main' parameter given",
         ),
         (
-            json.dumps({
-                "type": "program",
-                "id": "1234",
-                "data": {"code": {"": {"entry": ""}}, "main": {"modulepath": "1", "module": "2"}},
-            }),
-            "Invalid 'main' parameter given",
+                json.dumps({
+                    "type": "program",
+                    "id": "1234",
+                    "data": {"code": {"": {"entry": ""}}, "main": {"modulepath": "1", "module": "2"}},
+                }),
+                "Invalid 'main' parameter given",
         ),
         (
-            json.dumps({
-                "type": "program",
-                "id": "1234",
-                "data": {"code": {"": {"entry": ""}}, "main": {"modulepath": "1", "pipeline": "3"}},
-            }),
-            "Invalid 'main' parameter given",
+                json.dumps({
+                    "type": "program",
+                    "id": "1234",
+                    "data": {"code": {"": {"entry": ""}}, "main": {"modulepath": "1", "pipeline": "3"}},
+                }),
+                "Invalid 'main' parameter given",
         ),
         (
-            json.dumps({
-                "type": "program",
-                "id": "1234",
-                "data": {"code": {"": {"entry": ""}}, "main": {"module": "2", "pipeline": "3"}},
-            }),
-            "Invalid 'main' parameter given",
+                json.dumps({
+                    "type": "program",
+                    "id": "1234",
+                    "data": {"code": {"": {"entry": ""}}, "main": {"module": "2", "pipeline": "3"}},
+                }),
+                "Invalid 'main' parameter given",
         ),
         (
-            json.dumps({
-                "type": "program",
-                "id": "1234",
-                "data": {
-                    "code": {"": {"entry": ""}},
-                    "main": {"modulepath": "1", "module": "2", "pipeline": "3", "other": "4"},
-                },
-            }),
-            "Invalid 'main' parameter given",
+                json.dumps({
+                    "type": "program",
+                    "id": "1234",
+                    "data": {
+                        "code": {"": {"entry": ""}},
+                        "main": {"modulepath": "1", "module": "2", "pipeline": "3", "other": "4"},
+                    },
+                }),
+                "Invalid 'main' parameter given",
         ),
         (
-            json.dumps({
-                "type": "program",
-                "id": "1234",
-                "data": {
-                    "code": {"": {"entry": ""}},
-                    "main": {"modulepath": "1", "module": "2", "pipeline": "3", "other": {"4": "a"}},
-                },
-            }),
-            "Invalid 'main' parameter given",
+                json.dumps({
+                    "type": "program",
+                    "id": "1234",
+                    "data": {
+                        "code": {"": {"entry": ""}},
+                        "main": {"modulepath": "1", "module": "2", "pipeline": "3", "other": {"4": "a"}},
+                    },
+                }),
+                "Invalid 'main' parameter given",
         ),
         (
-            json.dumps({
-                "type": "program",
-                "id": "1234",
-                "data": {"code": "a", "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
-            }),
-            "Invalid 'code' parameter given",
+                json.dumps({
+                    "type": "program",
+                    "id": "1234",
+                    "data": {"code": "a", "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
+                }),
+                "Invalid 'code' parameter given",
         ),
         (
-            json.dumps({
-                "type": "program",
-                "id": "1234",
-                "data": {"code": {"": "a"}, "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
-            }),
-            "Invalid 'code' parameter given",
+                json.dumps({
+                    "type": "program",
+                    "id": "1234",
+                    "data": {"code": {"": "a"}, "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
+                }),
+                "Invalid 'code' parameter given",
         ),
         (
-            json.dumps({
-                "type": "program",
-                "id": "1234",
-                "data": {"code": {"": {"a": {"b": "c"}}}, "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
-            }),
-            "Invalid 'code' parameter given",
+                json.dumps({
+                    "type": "program",
+                    "id": "1234",
+                    "data": {"code": {"": {"a": {"b": "c"}}},
+                             "main": {"modulepath": "1", "module": "2", "pipeline": "3"}},
+                }),
+                "Invalid 'code' parameter given",
         ),
     ],
     ids=[
@@ -182,39 +183,39 @@ def test_should_fail_message_validation(websocket_message: str, exception_messag
 @pytest.mark.skipif(
     sys.platform.startswith("win") and os.getenv("COVERAGE_RCFILE") is not None,
     reason=(
-        "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
-        "causes Manager to hang, when using multiprocessing coverage"
+            "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
+            "causes Manager to hang, when using multiprocessing coverage"
     ),
 )
 @pytest.mark.parametrize(
     argnames="messages,expected_response_runtime_error",
     argvalues=[
         (
-            [
-                json.dumps({
-                    "type": "program",
-                    "id": "abcdefgh",
-                    "data": {
-                        "code": {
-                            "": {
-                                "gen_test_a": "def pipe():\n\traise Exception('Test Exception')\n",
-                                "gen_test_a_pipe": (
-                                    "from gen_test_a import pipe\n\nif __name__ == '__main__':\n\tpipe()"
-                                ),
+                [
+                    json.dumps({
+                        "type": "program",
+                        "id": "abcdefgh",
+                        "data": {
+                            "code": {
+                                "": {
+                                    "gen_test_a": "def pipe():\n\traise Exception('Test Exception')\n",
+                                    "gen_test_a_pipe": (
+                                            "from gen_test_a import pipe\n\nif __name__ == '__main__':\n\tpipe()"
+                                    ),
+                                },
                             },
+                            "main": {"modulepath": "", "module": "test_a", "pipeline": "pipe"},
                         },
-                        "main": {"modulepath": "", "module": "test_a", "pipeline": "pipe"},
-                    },
-                }),
-            ],
-            Message(message_type_runtime_error, "abcdefgh", {"message": "Test Exception"}),
+                    }),
+                ],
+                Message(message_type_runtime_error, "abcdefgh", {"message": "Test Exception"}),
         ),
     ],
     ids=["raise_exception"],
 )
 def test_should_execute_pipeline_return_exception(
-    messages: list[str],
-    expected_response_runtime_error: Message,
+        messages: list[str],
+        expected_response_runtime_error: Message,
 ) -> None:
     mock_connection = MockWebsocketConnection(messages)
     app_pipeline_manager.set_new_websocket_target(mock_connection)
@@ -238,71 +239,71 @@ def test_should_execute_pipeline_return_exception(
 @pytest.mark.skipif(
     sys.platform.startswith("win") and os.getenv("COVERAGE_RCFILE") is not None,
     reason=(
-        "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
-        "causes Manager to hang, when using multiprocessing coverage"
+            "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
+            "causes Manager to hang, when using multiprocessing coverage"
     ),
 )
 @pytest.mark.parametrize(
     argnames="initial_messages,initial_execution_message_wait,appended_messages,expected_responses",
     argvalues=[
         (
-            [
-                json.dumps({
-                    "type": "program",
-                    "id": "abcdefg",
-                    "data": {
-                        "code": {
-                            "": {
-                                "gen_test_a": (
-                                    "import safeds_runner.server.pipeline_manager\n\ndef pipe():\n\tvalue1 ="
-                                    " 1\n\tsafeds_runner.server.pipeline_manager.runner_save_placeholder('value1',"
-                                    " value1)\n\tsafeds_runner.server.pipeline_manager.runner_save_placeholder('obj',"
-                                    " object())\n"
-                                ),
-                                "gen_test_a_pipe": (
-                                    "from gen_test_a import pipe\n\nif __name__ == '__main__':\n\tpipe()"
-                                ),
+                [
+                    json.dumps({
+                        "type": "program",
+                        "id": "abcdefg",
+                        "data": {
+                            "code": {
+                                "": {
+                                    "gen_test_a": (
+                                            "import safeds_runner.server.pipeline_manager\n\ndef pipe():\n\tvalue1 ="
+                                            " 1\n\tsafeds_runner.server.pipeline_manager.runner_save_placeholder('value1',"
+                                            " value1)\n\tsafeds_runner.server.pipeline_manager.runner_save_placeholder('obj',"
+                                            " object())\n"
+                                    ),
+                                    "gen_test_a_pipe": (
+                                            "from gen_test_a import pipe\n\nif __name__ == '__main__':\n\tpipe()"
+                                    ),
+                                },
                             },
+                            "main": {"modulepath": "", "module": "test_a", "pipeline": "pipe"},
                         },
-                        "main": {"modulepath": "", "module": "test_a", "pipeline": "pipe"},
-                    },
-                }),
-            ],
-            2,
-            [
-                # Query Placeholder
-                json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "value1"}),
-                # Query not displayable Placeholder
-                json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "obj"}),
-                # Query invalid placeholder
-                json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "value2"}),
-            ],
-            [
-                # Validate Placeholder Information
-                Message(message_type_placeholder_type, "abcdefg", create_placeholder_description("value1", "Int")),
-                Message(message_type_placeholder_type, "abcdefg", create_placeholder_description("obj", "object")),
-                # Validate Progress Information
-                Message(message_type_runtime_progress, "abcdefg", create_runtime_progress_done()),
-                # Query Result Valid
-                Message(message_type_placeholder_value, "abcdefg", create_placeholder_value("value1", "Int", 1)),
-                # Query Result not displayable
-                Message(
-                    message_type_placeholder_value,
-                    "abcdefg",
-                    create_placeholder_value("obj", "object", "<Not displayable>"),
-                ),
-                # Query Result Invalid
-                Message(message_type_placeholder_value, "abcdefg", create_placeholder_value("value2", "", "")),
-            ],
+                    }),
+                ],
+                2,
+                [
+                    # Query Placeholder
+                    json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "value1"}),
+                    # Query not displayable Placeholder
+                    json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "obj"}),
+                    # Query invalid placeholder
+                    json.dumps({"type": "placeholder_query", "id": "abcdefg", "data": "value2"}),
+                ],
+                [
+                    # Validate Placeholder Information
+                    Message(message_type_placeholder_type, "abcdefg", create_placeholder_description("value1", "Int")),
+                    Message(message_type_placeholder_type, "abcdefg", create_placeholder_description("obj", "object")),
+                    # Validate Progress Information
+                    Message(message_type_runtime_progress, "abcdefg", create_runtime_progress_done()),
+                    # Query Result Valid
+                    Message(message_type_placeholder_value, "abcdefg", create_placeholder_value("value1", "Int", 1)),
+                    # Query Result not displayable
+                    Message(
+                        message_type_placeholder_value,
+                        "abcdefg",
+                        create_placeholder_value("obj", "object", "<Not displayable>"),
+                    ),
+                    # Query Result Invalid
+                    Message(message_type_placeholder_value, "abcdefg", create_placeholder_value("value2", "", "")),
+                ],
         ),
     ],
     ids=["query_valid_query_invalid"],
 )
 def test_should_execute_pipeline_return_valid_placeholder(
-    initial_messages: list[str],
-    initial_execution_message_wait: int,
-    appended_messages: list[str],
-    expected_responses: list[Message],
+        initial_messages: list[str],
+        initial_execution_message_wait: int,
+        appended_messages: list[str],
+        expected_responses: list[Message],
 ) -> None:
     # Initial execution
     mock_connection = MockWebsocketConnection(initial_messages)
@@ -323,58 +324,58 @@ def test_should_execute_pipeline_return_valid_placeholder(
 @pytest.mark.skipif(
     sys.platform.startswith("win") and os.getenv("COVERAGE_RCFILE") is not None,
     reason=(
-        "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
-        "causes Manager to hang, when using multiprocessing coverage"
+            "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
+            "causes Manager to hang, when using multiprocessing coverage"
     ),
 )
 @pytest.mark.parametrize(
     argnames="messages,expected_response",
     argvalues=[
         (
-            [
-                json.dumps({
-                    "type": "program",
-                    "id": "123456789",
-                    "data": {
-                        "code": {
-                            "": {
-                                "gen_b": (
-                                    "import safeds_runner.codegen\n"
-                                    "from a.stub import u\n"
-                                    "from v.u.s.testing import add1\n"
-                                    "\n"
-                                    "def c():\n"
-                                    "\ta1 = 1\n"
-                                    "\ta2 = safeds_runner.codegen.eager_or(True, False)\n"
-                                    "\tprint('test2')\n"
-                                    "\tprint('new dynamic output')\n"
-                                    "\tprint(f'Add1: {add1(1, 2)}')\n"
-                                    "\treturn a1 + a2\n"
-                                ),
-                                "gen_b_c": "from gen_b import c\n\nif __name__ == '__main__':\n\tc()",
+                [
+                    json.dumps({
+                        "type": "program",
+                        "id": "123456789",
+                        "data": {
+                            "code": {
+                                "": {
+                                    "gen_b": (
+                                            "import safeds_runner.codegen\n"
+                                            "from a.stub import u\n"
+                                            "from v.u.s.testing import add1\n"
+                                            "\n"
+                                            "def c():\n"
+                                            "\ta1 = 1\n"
+                                            "\ta2 = safeds_runner.codegen.eager_or(True, False)\n"
+                                            "\tprint('test2')\n"
+                                            "\tprint('new dynamic output')\n"
+                                            "\tprint(f'Add1: {add1(1, 2)}')\n"
+                                            "\treturn a1 + a2\n"
+                                    ),
+                                    "gen_b_c": "from gen_b import c\n\nif __name__ == '__main__':\n\tc()",
+                                },
+                                "a": {"stub": "def u():\n\treturn 1"},
+                                "v.u.s": {
+                                    "testing": "import a.stub;\n\ndef add1(v1, v2):\n\treturn v1 + v2 + a.stub.u()\n",
+                                },
                             },
-                            "a": {"stub": "def u():\n\treturn 1"},
-                            "v.u.s": {
-                                "testing": "import a.stub;\n\ndef add1(v1, v2):\n\treturn v1 + v2 + a.stub.u()\n",
-                            },
+                            "main": {"modulepath": "", "module": "b", "pipeline": "c"},
                         },
-                        "main": {"modulepath": "", "module": "b", "pipeline": "c"},
-                    },
-                }),
-            ],
-            Message(message_type_runtime_progress, "123456789", create_runtime_progress_done()),
+                    }),
+                ],
+                Message(message_type_runtime_progress, "123456789", create_runtime_progress_done()),
         ),
         (
-            # Query Result Invalid (no pipeline exists)
-            [
-                json.dumps({"type": "invalid_message_type", "id": "unknown-code-id-never-generated", "data": ""}),
-                json.dumps({"type": "placeholder_query", "id": "unknown-code-id-never-generated", "data": "v"}),
-            ],
-            Message(
-                message_type_placeholder_value,
-                "unknown-code-id-never-generated",
-                create_placeholder_value("v", "", ""),
-            ),
+                # Query Result Invalid (no pipeline exists)
+                [
+                    json.dumps({"type": "invalid_message_type", "id": "unknown-code-id-never-generated", "data": ""}),
+                    json.dumps({"type": "placeholder_query", "id": "unknown-code-id-never-generated", "data": "v"}),
+                ],
+                Message(
+                    message_type_placeholder_value,
+                    "unknown-code-id-never-generated",
+                    create_placeholder_value("v", "", ""),
+                ),
         ),
     ],
     ids=["progress_message_done", "invalid_message_invalid_placeholder_query"],
@@ -391,8 +392,8 @@ def test_should_successfully_execute_simple_flow(messages: list[str], expected_r
 @pytest.mark.skipif(
     sys.platform.startswith("win") and os.getenv("COVERAGE_RCFILE") is not None,
     reason=(
-        "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
-        "causes Manager to hang, when using multiprocessing coverage"
+            "skipping multiprocessing tests on windows if coverage is enabled, as pytest "
+            "causes Manager to hang, when using multiprocessing coverage"
     ),
 )
 @pytest.mark.parametrize(
@@ -419,6 +420,7 @@ def helper_should_shut_itself_down_run_in_subprocess(sub_messages: list[str]) ->
 helper_should_shut_itself_down_run_in_subprocess.__test__ = False  # type: ignore[attr-defined]
 
 
+@pytest.mark.skip
 @pytest.mark.timeout(45)
 def test_should_accept_at_least_2_parallel_connections_in_subprocess() -> None:
     port = 6000
@@ -440,7 +442,7 @@ def test_should_accept_at_least_2_parallel_connections_in_subprocess() -> None:
         client2 = simple_websocket.Client.connect(f"ws://127.0.0.1:{port}/WSMain")
         connected = client1.connected and client2.connected
     except ConnectionRefusedError as e:
-        logging.warning(f"Connection refused: {e}")
+        logging.warning("Connection refused: %s", e)
         connected = False
     if client1 is not None and client1.connected:
         client1.send('{"id": "", "type": "shutdown", "data": ""}')
@@ -450,7 +452,8 @@ def test_should_accept_at_least_2_parallel_connections_in_subprocess() -> None:
     assert connected
 
 
-def helper_should_accept_at_least_2_parallel_connections_in_subprocess_server(port: int, pipe: multiprocessing.connection.Connection) -> None:
+def helper_should_accept_at_least_2_parallel_connections_in_subprocess_server(port: int,
+                                                                              pipe: multiprocessing.connection.Connection) -> None:
     sys.stderr.write = lambda value: pipe.send(value)  # type: ignore[method-assign, assignment]
     sys.stdout.write = lambda value: pipe.send(value)  # type: ignore[method-assign, assignment]
     safeds_runner.server.main.start_server(port)

--- a/tests/safeds_runner/server/test_websocket_mock.py
+++ b/tests/safeds_runner/server/test_websocket_mock.py
@@ -170,6 +170,7 @@ class MockWebsocketConnection:
 )
 def test_should_fail_message_validation(websocket_message: str, exception_message: str) -> None:
     mock_connection = MockWebsocketConnection([websocket_message])
+    app_pipeline_manager.set_new_websocket_target(mock_connection)
     ws_main(mock_connection, app_pipeline_manager)
     assert str(mock_connection.close_message) == exception_message
 
@@ -212,6 +213,7 @@ def test_should_execute_pipeline_return_exception(
     expected_response_runtime_error: Message,
 ) -> None:
     mock_connection = MockWebsocketConnection(messages)
+    app_pipeline_manager.set_new_websocket_target(mock_connection)
     ws_main(mock_connection, app_pipeline_manager)
     mock_connection.wait_for_messages(1)
     exception_message = Message.from_dict(json.loads(mock_connection.get_next_received_message()))
@@ -300,6 +302,7 @@ def test_should_execute_pipeline_return_valid_placeholder(
 ) -> None:
     # Initial execution
     mock_connection = MockWebsocketConnection(initial_messages)
+    app_pipeline_manager.set_new_websocket_target(mock_connection)
     ws_main(mock_connection, app_pipeline_manager)
     # Wait for at least enough messages to successfully execute pipeline
     mock_connection.wait_for_messages(initial_execution_message_wait)
@@ -374,6 +377,7 @@ def test_should_execute_pipeline_return_valid_placeholder(
 )
 def test_should_successfully_execute_simple_flow(messages: list[str], expected_response: Message) -> None:
     mock_connection = MockWebsocketConnection(messages)
+    app_pipeline_manager.set_new_websocket_target(mock_connection)
     ws_main(mock_connection, app_pipeline_manager)
     mock_connection.wait_for_messages(1)
     query_result_invalid = Message.from_dict(json.loads(mock_connection.get_next_received_message()))


### PR DESCRIPTION
- fix: allow multiple websocket connections in parallel (custom threading / multiprocessing is initialized before patching for use with gevent)
- feat: send events (during execution) to all connected (listening) websocket connections
- Queries (placeholder_query) is still using a request-response pattern and does not multicast to all connections
- green thread pool size for connections is limited to 8 for now