### PR TITLE
docs: remove type hints from docstrings

### DIFF
--- a/src/safeds_runner/server/_json_encoder.py
+++ b/src/safeds_runner/server/_json_encoder.py
@@ -19,12 +19,12 @@ class SafeDsEncoder(json.JSONEncoder):
 
         Parameters
         ----------
-        o: Any
+        o:
             An object that needs to be encoded to JSON.
 
         Returns
         -------
-        Any
+        json_serializable:
             The passed object represented in a way that is serializable to JSON.
         """
         # Moving these imports to the top drastically increases startup time

--- a/src/safeds_runner/server/_memoization_map.py
+++ b/src/safeds_runner/server/_memoization_map.py
@@ -37,9 +37,9 @@ class MemoizationMap:
 
         Parameters
         ----------
-        map_values
+        map_values:
             Value store dictionary
-        map_stats
+        map_stats:
             Stats dictionary
         """
         self._map_values: dict[MemoizationKey, Any] = map_values
@@ -54,7 +54,8 @@ class MemoizationMap:
 
         Returns
         -------
-        Amount of bytes, this cache occupies. This may be an estimate.
+        cache_size:
+            Amount of bytes, this cache occupies. This may be an estimate.
         """
         return functools.reduce(
             operator.add,
@@ -70,7 +71,7 @@ class MemoizationMap:
 
         Parameters
         ----------
-        needed_capacity
+        needed_capacity:
             Amount of free storage space requested, in bytes
         """
         if self.max_size is None:
@@ -86,7 +87,7 @@ class MemoizationMap:
 
         Parameters
         ----------
-        capacity_to_free
+        capacity_to_free:
             Amount of bytes that should be additionally freed, after this function returns
         """
         copied_stats = list(self._map_stats.copy().items())
@@ -126,18 +127,19 @@ class MemoizationMap:
 
         Parameters
         ----------
-        function_name
+        function_name:
             Fully qualified function name
-        function_callable
+        function_callable:
             Function that is called and memoized if the result was not found in the memoization map
-        parameters
+        parameters:
             List of parameters passed to the function
-        hidden_parameters
+        hidden_parameters:
             List of hidden parameters for the function. This is used for memoizing some impure functions.
 
         Returns
         -------
-        The result of the specified function, if any exists
+        result:
+            The result of the specified function, if any exists
         """
         access_timestamp = time.time_ns()
 
@@ -198,12 +200,13 @@ class MemoizationMap:
 
         Parameters
         ----------
-        key
+        key:
             Memoization Key
 
         Returns
         -------
-        The value corresponding to the provided memoization key, if any exists.
+        value:
+            The value corresponding to the provided memoization key, if any exists.
         """
         looked_up_value = self._map_values.get(key)
         return _unwrap_value_from_shared_memory(looked_up_value)
@@ -214,11 +217,11 @@ class MemoizationMap:
 
         Parameters
         ----------
-        function_name
+        function_name:
             Fully qualified function name
-        access_timestamp
+        access_timestamp:
             Timestamp when this value was last accessed
-        lookup_time
+        lookup_time:
             Duration the comparison took in nanoseconds
         """
         stats = self._map_stats[function_name]
@@ -241,15 +244,15 @@ class MemoizationMap:
 
         Parameters
         ----------
-        function_name
+        function_name:
             Fully qualified function name
-        access_timestamp
+        access_timestamp:
             Timestamp when this value was last accessed
-        lookup_time
+        lookup_time:
             Duration the comparison took in nanoseconds
-        computation_time
+        computation_time:
             Duration the computation of the new value took in nanoseconds
-        memory_size
+        memory_size:
             Memory the newly computed value takes up in bytes
         """
         stats = self._map_stats.get(function_name)

--- a/src/safeds_runner/server/_memoization_stats.py
+++ b/src/safeds_runner/server/_memoization_stats.py
@@ -11,13 +11,13 @@ class MemoizationStats:
 
     Parameters
     ----------
-    access_timestamps
+    access_timestamps:
         Absolute timestamp since the unix epoch of the last access to the memoized value in nanoseconds
-    lookup_times
+    lookup_times:
         Duration the lookup of the value took in nanoseconds (key comparison + IPC)
-    computation_times
+    computation_times:
         Duration the computation of the value took in nanoseconds
-    memory_sizes
+    memory_sizes:
         Amount of memory the memoized value takes up in bytes
     """
 
@@ -32,9 +32,9 @@ class MemoizationStats:
 
         Parameters
         ----------
-        access_timestamp
+        access_timestamp:
             Timestamp when this value was last accessed
-        lookup_time
+        lookup_time:
             Duration the comparison took in nanoseconds
         """
         self.access_timestamps.append(access_timestamp)
@@ -46,13 +46,13 @@ class MemoizationStats:
 
         Parameters
         ----------
-        access_timestamp
+        access_timestamp:
             Timestamp when this value was last accessed
-        lookup_time
+        lookup_time:
             Duration the comparison took in nanoseconds
-        computation_time
+        computation_time:
             Duration the computation of the new value took in nanoseconds
-        memory_size
+        memory_size:
             Memory the newly computed value takes up in bytes
         """
         self.access_timestamps.append(access_timestamp)
@@ -66,7 +66,8 @@ class MemoizationStats:
 
         Returns
         -------
-        Summary of stats
+        string_representation:
+            Summary of stats
         """
         return (  # pragma: no cover
             f"Last access: {self.access_timestamps}, computation time: {self.computation_times}, lookup time:"

--- a/src/safeds_runner/server/_memoization_utils.py
+++ b/src/safeds_runner/server/_memoization_utils.py
@@ -35,12 +35,12 @@ class ExplicitIdentityWrapper:
 
         Parameters
         ----------
-        value
+        value:
             Object to create a shared memory based wrapper for.
 
         Returns
         -------
-        result
+        result:
             A new wrapper object containing the provided value.
         """
         _shared_memory_serialize_and_assign(value)
@@ -53,12 +53,12 @@ class ExplicitIdentityWrapper:
 
         Parameters
         ----------
-        value
+        value:
             Object to create a shared memory based wrapper for.
 
         Returns
         -------
-        result
+        result:
             A new wrapper object containing the provided value.
         """
         return cls(value, value.__ex_id_mem__)
@@ -113,12 +113,12 @@ class ExplicitIdentityWrapperLazy:
 
         Parameters
         ----------
-        value
+        value:
             Object to create a shared memory based wrapper for.
 
         Returns
         -------
-        result
+        result:
             A new wrapper object containing the provided value.
         """
         _shared_memory_serialize_and_assign(value)
@@ -131,12 +131,12 @@ class ExplicitIdentityWrapperLazy:
 
         Parameters
         ----------
-        value
+        value:
             Object to create a shared memory based wrapper for.
 
         Returns
         -------
-        result
+        result:
             A new wrapper object containing the provided value.
         """
         return cls(value, value.__ex_id_mem__, value.__ex_id__, value.__ex_hash__)
@@ -165,7 +165,7 @@ class ExplicitIdentityWrapperLazy:
 
         Returns
         -------
-        value
+        value:
             Wrapped value
         """
         if self._value is None:
@@ -193,12 +193,12 @@ def _is_not_primitive(value: Any) -> bool:
 
     Parameters
     ----------
-    value
+    value:
         Object to check, whether it is not primitive.
 
     Returns
     -------
-    result
+    result:
         True, if the object is not primitive.
     """
     return not isinstance(value, str | int | float | type(None) | bool)
@@ -212,12 +212,12 @@ def _is_deterministically_hashable(value: Any) -> bool:
 
     Parameters
     ----------
-    value
+    value:
         Object to check, if it is (probably) deterministically hashable.
 
     Returns
     -------
-    result
+    result:
         True, if the object can be deterministically hashed.
     """
     return _is_not_primitive(value) and hasattr(value, "__class__") and value.__class__.__hash__ != object.__hash__
@@ -229,12 +229,12 @@ def _has_explicit_identity(value: Any) -> bool:
 
     Parameters
     ----------
-    value
+    value:
         Object to check
 
     Returns
     -------
-    result
+    result:
         Whether the object has been assigned an explicit identity.
     """
     return hasattr(value, "__ex_id__")
@@ -246,12 +246,12 @@ def _has_explicit_identity_memory(value: Any) -> bool:
 
     Parameters
     ----------
-    value
+    value:
         Object to check
 
     Returns
     -------
-    result
+    result:
         Whether the object has been assigned shared memory location.
     """
     return hasattr(value, "__ex_id_mem__")
@@ -263,7 +263,7 @@ def _set_new_explicit_identity_deterministic_hash(value: Any) -> None:
 
     Parameters
     ----------
-    value
+    value:
         Object to assign an explicit identity and a deterministic hash to
     """
     value.__ex_id__ = uuid.uuid4()
@@ -276,7 +276,7 @@ def _set_new_explicit_identity(value: Any) -> None:
 
     Parameters
     ----------
-    value
+    value:
         Object to assign an explicit identity to
     """
     value.__ex_id__ = uuid.uuid4()
@@ -288,7 +288,7 @@ def _set_new_explicit_memory(value: Any, memory: SharedMemory) -> None:
 
     Parameters
     ----------
-    value
+    value:
         Object to assign a shared memory location to
     """
     value.__ex_id_mem__ = memory
@@ -300,12 +300,12 @@ def _shared_memory_serialize_and_assign(value: Any) -> SharedMemory:
 
     Parameters
     ----------
-    value
+    value:
         Any value that should be stored in a shared memory location
 
     Returns
     -------
-    memory
+    memory:
         Shared Memory location containing the provided object in a serialized representation.
     """
     bytes_dump = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
@@ -322,7 +322,7 @@ def _make_hashable(value: Any) -> Any:
 
     Parameters
     ----------
-    value
+    value:
         Value to be converted.
 
     Returns
@@ -354,12 +354,13 @@ def _get_size_of_value(value: Any) -> int:
 
     Parameters
     ----------
-    value
+    value:
         Any value of which the memory usage should be calculated.
 
     Returns
     -------
-    Size of the provided value in bytes
+    size:
+        Size of the provided value in bytes
     """
     size_immediate = sys.getsizeof(value)
     if isinstance(value, dict):
@@ -382,16 +383,17 @@ def _create_memoization_key(
 
     Parameters
     ----------
-    function_name
+    function_name:
         Fully qualified function name
-    parameters
+    parameters:
         List of parameters passed to the function
-    hidden_parameters
+    hidden_parameters:
         List of parameters not passed to the function
 
     Returns
     -------
-    A memoization key, which contains the lists converted to tuples
+    key:
+        A memoization key, which contains the lists converted to tuples
     """
     return function_name, _make_hashable(parameters), _make_hashable(hidden_parameters)
 
@@ -404,12 +406,12 @@ def _wrap_value_to_shared_memory(
 
     Parameters
     ----------
-    result
+    result:
         Value to convert to memoizable format.
 
     Returns
     -------
-    value
+    value:
         The value in a memoizable format, wrapped if needed.
     """
     if isinstance(result, tuple):
@@ -439,12 +441,12 @@ def _unwrap_value_from_shared_memory(
 
     Parameters
     ----------
-    result
+    result:
         Value to convert to a usable format.
 
     Returns
     -------
-    value
+    value:
         The value in a usable format, unwrapped if needed.
     """
     if isinstance(result, tuple):

--- a/src/safeds_runner/server/_messages.py
+++ b/src/safeds_runner/server/_messages.py
@@ -35,11 +35,11 @@ class Message:
 
     Parameters
     ----------
-    type : str
+    type:
         Type that identifies the kind of message.
-    id : str
+    id:
         ID that identifies the execution where this message belongs to.
-    data : Any
+    data:
         Message data section. Differs between message types.
     """
 
@@ -54,12 +54,12 @@ class Message:
 
         Parameters
         ----------
-        d : dict[str, Any]
+        d:
             Dictionary which should contain all needed fields.
 
         Returns
         -------
-        Message
+        message:
             Dataclass which contains information copied from the provided dictionary.
         """
         return Message(**d)
@@ -70,7 +70,7 @@ class Message:
 
         Returns
         -------
-        dict[str, Any]
+        dict:
             Dictionary containing all the fields which are part of this dataclass.
         """
         return dataclasses.asdict(self)
@@ -82,7 +82,7 @@ class ProgramMessage(BaseModel):
 
     Parameters
     ----------
-    data : ProgramMessageData
+    data:
         Data of the program message.
     """
 
@@ -98,11 +98,11 @@ class ProgramMessageData(BaseModel):
 
     Parameters
     ----------
-    code : dict[str, dict[str, str]]
+    code:
         A dictionary containing the code needed for executed,
         in a virtual filesystem. Keys of the outer dictionary are the module path, keys of the inner dictionary are the
         module name. The values of the inner dictionary is the python code for each module.
-    main : ProgramMessageMainInformation
+    main:
         Information where the main pipeline (the pipeline to be executed) is located.
     cwd:
         Current working directory to use for execution. If not set, the default working directory is used.
@@ -121,11 +121,11 @@ class ProgramMessageMainInformation(BaseModel):
 
     Parameters
     ----------
-    modulepath : str
+    modulepath:
         Path, where the main module is located.
-    module : str
+    module:
         Safe-DS module name.
-    pipeline : str
+    pipeline:
         Safe-DS pipeline name.
     """
 
@@ -142,7 +142,7 @@ class QueryMessage(BaseModel):
 
     Parameters
     ----------
-    data : QueryMessageData
+    data:
         Data of the placeholder query message.
     """
 
@@ -158,9 +158,9 @@ class QueryMessageWindow(BaseModel):
 
     Parameters
     ----------
-    begin : int | None
+    begin:
         Index of the first entry that should be sent. May be present if a windowed query is required.
-    size : int | None
+    size:
         Max. amount of entries that should be sent. May be present if a windowed query is required.
     """
 
@@ -176,9 +176,9 @@ class QueryMessageData(BaseModel):
 
     Parameters
     ----------
-    name : str
+    name:
         Placeholder name that is queried.
-    window : QueryMessageWindow
+    window:
         Window bounds for requesting only a subset of the available data.
     """
 
@@ -194,14 +194,14 @@ def create_placeholder_description(name: str, type_: str) -> dict[str, str]:
 
     Parameters
     ----------
-    name : str
+    name:
         Name of the placeholder.
-    type_ : str
+    type_:
         Type of the placeholder.
 
     Returns
     -------
-    dict[str, str]
+    message_data:
         Message data of "placeholder_type" messages.
     """
     return {"name": name, "type": type_}
@@ -216,16 +216,16 @@ def create_placeholder_value(placeholder_query: QueryMessageData, type_: str, va
 
     Parameters
     ----------
-    placeholder_query : QueryMessageData
+    placeholder_query:
         Query of the placeholder.
-    type_ : str
+    type_:
         Type of the placeholder.
-    value : Any
+    value:
         Value of the placeholder.
 
     Returns
     -------
-    dict[str, str]
+    message_data:
         Message data of "placeholder_value" messages.
     """
     import safeds.data.tabular.containers
@@ -256,14 +256,14 @@ def create_runtime_error_description(message: str, backtrace: list[dict[str, Any
 
     Parameters
     ----------
-    message : str
+    message:
         Error information message.
-    backtrace : list[dict[str, Any]]
+    backtrace:
         Python backtrace of the error. Each list entry represents a stack frame.
 
     Returns
     -------
-    dict[str, Any]
+    message_data:
         Message data of "runtime_error" messages.
     """
     return {"message": message, "backtrace": backtrace}
@@ -275,7 +275,7 @@ def create_runtime_progress_done() -> str:
 
     Returns
     -------
-    str
+    str:
         Message data of "runtime_progress" messages.
     """
     return "done"
@@ -287,12 +287,12 @@ def parse_validate_message(message: str) -> tuple[Message | None, str | None, st
 
     Parameters
     ----------
-    message : str
+    message:
         Message string, that should be in JSON format.
 
     Returns
     -------
-    tuple[Message | None, str | None, str | None]
+    message_or_error:
         A tuple containing either a message or a detailed error description and a short error message.
     """
     try:

--- a/src/safeds_runner/server/_module_manager.py
+++ b/src/safeds_runner/server/_module_manager.py
@@ -19,9 +19,9 @@ class InMemoryLoader(importlib.abc.SourceLoader, ABC):
 
         Parameters
         ----------
-        code_bytes : bytes
+        code_bytes:
             Byte array containing python code.
-        filename : str
+        filename:
             Filename of the python module.
         """
         self.code_bytes = code_bytes
@@ -33,12 +33,12 @@ class InMemoryLoader(importlib.abc.SourceLoader, ABC):
 
         Parameters
         ----------
-        _path : bytes | str
+        _path:
             Module path.
 
         Returns
         -------
-        bytes
+        code_as_bytes:
             Module code.
         """
         return self.code_bytes
@@ -49,12 +49,12 @@ class InMemoryLoader(importlib.abc.SourceLoader, ABC):
 
         Parameters
         ----------
-        _fullname : str
+        _fullname:
             Module path.
 
         Returns
         -------
-        str
+        filename:
             virtual module path, as located in the code array in the InMemoryFinder that created this loader.
         """
         return self.filename
@@ -69,7 +69,7 @@ class InMemoryFinder(importlib.abc.MetaPathFinder):
 
         Parameters
         ----------
-        code : dict[str, dict[str, str]]
+        code:
             A dictionary containing the code to be executed,
             grouped by module path containing a mapping from module name to module code.
         """
@@ -95,16 +95,16 @@ class InMemoryFinder(importlib.abc.MetaPathFinder):
 
         Parameters
         ----------
-        fullname : str
+        fullname:
             Full module path (separated with '.').
-        path : typing.Sequence[str] | None
+        path:
             Module Path.
-        target : types.ModuleType | None
+        target:
             Module Type.
 
         Returns
         -------
-        ModuleSpec | None
+        module_spec:
             A module spec, if found. None otherwise
         """
         logging.debug("Find Spec: %s %s %s", fullname, path, target)

--- a/src/safeds_runner/server/_pipeline_manager.py
+++ b/src/safeds_runner/server/_pipeline_manager.py
@@ -99,7 +99,7 @@ class PipelineManager:
 
         Parameters
         ----------
-        event_loop : asyncio.AbstractEventLoop
+        event_loop:
             Event Loop that handles websocket connections.
         """
         try:
@@ -118,7 +118,7 @@ class PipelineManager:
 
         Parameters
         ----------
-        websocket_connection_queue : asyncio.Queue
+        websocket_connection_queue:
             Message Queue for a websocket connection.
         """
         self._websocket_target.append(websocket_connection_queue)
@@ -129,7 +129,7 @@ class PipelineManager:
 
         Parameters
         ----------
-        websocket_connection_queue : asyncio.Queue
+        websocket_connection_queue:
             Message Queue for a websocket connection to be removed.
         """
         self._websocket_target.remove(websocket_connection_queue)
@@ -144,9 +144,9 @@ class PipelineManager:
 
         Parameters
         ----------
-        pipeline : ProgramMessageData
+        pipeline:
             Message object that contains the information to run a pipeline.
-        execution_id : str
+        execution_id:
             Unique ID to identify this execution.
         """
         self.startup()
@@ -167,14 +167,14 @@ class PipelineManager:
 
         Parameters
         ----------
-        execution_id : str
+        execution_id:
             Unique ID identifying the execution in which the placeholder was calculated.
-        placeholder_name : str
+        placeholder_name:
             Name of the placeholder.
 
         Returns
         -------
-        tuple[str | None, Any]
+        placeholder:
             Tuple containing placeholder type and placeholder value, or (None, None) if the placeholder does not exist.
         """
         if execution_id not in self._placeholder_map:
@@ -212,15 +212,15 @@ class PipelineProcess:
 
         Parameters
         ----------
-        pipeline : ProgramMessageData
+        pipeline:
             Message object that contains the information to run a pipeline.
-        execution_id : str
+        execution_id:
             Unique ID to identify this process.
-        messages_queue : queue.Queue[Message]
+        messages_queue:
             A queue to write outgoing messages to.
-        placeholder_map : dict[str, Any]
+        placeholder_map:
             A map to save calculated placeholders in.
-        memoization_map : MemoizationMap
+        memoization_map:
             A map to save memoizable functions in.
         """
         self._pipeline = pipeline
@@ -242,9 +242,9 @@ class PipelineProcess:
 
         Parameters
         ----------
-        placeholder_name : str
+        placeholder_name:
             Name of the placeholder.
-        value : Any
+        value:
             Actual value of the placeholder.
         """
         from safeds.data.image.containers import Image
@@ -274,7 +274,7 @@ class PipelineProcess:
 
         Returns
         -------
-        MemoizationMap
+        memoization_map:
             Memoization Map
         """
         return self._memoization_map
@@ -338,9 +338,9 @@ def save_placeholder(placeholder_name: str, value: Any) -> None:
 
     Parameters
     ----------
-    placeholder_name : str
+    placeholder_name:
         Name of the placeholder.
-    value : Any
+    value:
         Actual value of the placeholder.
     """
     if current_pipeline is not None:
@@ -360,18 +360,18 @@ def memoized_static_call(
 
     Parameters
     ----------
-    function_name : str
+    function_name:
         Fully qualified function name
-    function_callable : typing.Callable
+    function_callable:
         Function that is called and memoized if the result was not found in the memoization map
-    parameters : list[Any]
+    parameters:
         List of parameters for the function
-    hidden_parameters : list[Any]
+    hidden_parameters:
         List of hidden parameters for the function. This is used for memoizing some impure functions.
 
     Returns
     -------
-    Any
+    result:
         The result of the specified function, if any exists
     """
     if current_pipeline is None:
@@ -395,18 +395,18 @@ def memoized_dynamic_call(
 
     Parameters
     ----------
-    function_name : str
+    function_name:
         Simple function name
-    function_callable : typing.Callable | None
+    function_callable:
         Function that is called and memoized if the result was not found in the memoization map or none, if the function handle should be in the provided instance
-    parameters : list[Any]
+    parameters:
         List of parameters for the function, the first parameter should be the instance the function should be called on (receiver)
-    hidden_parameters : list[Any]
+    hidden_parameters:
         List of hidden parameters for the function. This is used for memoizing some impure functions.
 
     Returns
     -------
-    Any
+    result:
         The result of the specified function, if any exists
     """
     if current_pipeline is None:
@@ -491,12 +491,12 @@ def get_backtrace_info(error: BaseException) -> list[dict[str, Any]]:
 
     Parameters
     ----------
-    error : BaseException
+    error:
         Caught exception.
 
     Returns
     -------
-    list[dict[str, Any]]
+    backtrace_info:
         List containing file and line information for each stack frame.
     """
     backtrace_list = []
@@ -511,12 +511,12 @@ def _get_placeholder_type(value: Any) -> str:
 
     Parameters
     ----------
-    value : Any
+    value:
         A python object.
 
     Returns
     -------
-    str
+    placeholder_type:
         Safe-DS name corresponding to the given python object instance.
     """
     match value:

--- a/src/safeds_runner/server/_server.py
+++ b/src/safeds_runner/server/_server.py
@@ -28,7 +28,7 @@ def create_flask_app() -> quart.app.Quart:
 
     Returns
     -------
-    quart.app.Quart
+    app:
         App.
     """
     return quart.app.Quart(__name__)
@@ -50,7 +50,7 @@ class SafeDsServer:
 
         Parameters
         ----------
-        port : int
+        port:
             Port to listen on
         """
         logging.info("Starting Safe-DS Runner on port %s", str(port))
@@ -76,9 +76,9 @@ class SafeDsServer:
 
         Parameters
         ----------
-        ws : quart.Websocket
+        ws:
             Connection
-        pipeline_manager : PipelineManager
+        pipeline_manager:
             Pipeline Manager
         """
         logging.debug("Request to WSRunProgram")
@@ -197,9 +197,9 @@ async def send_message(connection: quart.Websocket, message: Message) -> None:
 
     Parameters
     ----------
-    connection : quart.Websocket
+    connection:
         Connection that should receive the message.
-    message : Message
+    message:
         Object that will be sent.
     """
     message_encoded = json.dumps(message.to_dict(), cls=SafeDsEncoder)


### PR DESCRIPTION
Closes #40

### Summary of Changes

We've had a few cases in the past where type hints in the docs and in the code disagreed. Unfortunately, PyCharm prefers the types in the docs in this case, leading to confusion. Now, only the code contains type hints.
