### PR TITLE
feat: pass keyword arguments separately in memoized calls

### DIFF
--- a/src/safeds_runner/server/_memoization_utils.py
+++ b/src/safeds_runner/server/_memoization_utils.py
@@ -374,28 +374,32 @@ def _get_size_of_value(value: Any) -> int:
 
 
 def _create_memoization_key(
-    function_name: str,
-    parameters: list[Any],
-    hidden_parameters: list[Any],
+    fully_qualified_function_name: str,
+    positional_arguments: list[Any],
+    keyword_arguments: dict[str, Any],
+    hidden_arguments: list[Any],
 ) -> MemoizationKey:
     """
     Convert values provided to a memoized function call to a memoization key.
 
     Parameters
     ----------
-    function_name:
+    fully_qualified_function_name:
         Fully qualified function name
-    parameters:
-        List of parameters passed to the function
-    hidden_parameters:
-        List of parameters not passed to the function
+    positional_arguments:
+        List of arguments passed to the function
+    keyword_arguments:
+        Dictionary of keyword arguments passed to the function
+    hidden_arguments:
+        List of arguments not passed to the function
 
     Returns
     -------
     key:
         A memoization key, which contains the lists converted to tuples
     """
-    return function_name, _make_hashable(parameters), _make_hashable(hidden_parameters)
+    arguments = [*positional_arguments, *keyword_arguments.values()]
+    return fully_qualified_function_name, _make_hashable(arguments), _make_hashable(hidden_arguments)
 
 
 def _wrap_value_to_shared_memory(

--- a/tests/safeds_runner/server/test_memoization.py
+++ b/tests/safeds_runner/server/test_memoization.py
@@ -72,11 +72,13 @@ def test_memoization_static_already_present_values(
             _make_hashable(hidden_arguments),
         )
     ] = expected_result
-    _pipeline_manager.current_pipeline.get_memoization_map()._map_stats[fully_qualified_function_name] = MemoizationStats(
-        [time.perf_counter_ns()],
-        [],
-        [],
-        [sys.getsizeof(expected_result)],
+    _pipeline_manager.current_pipeline.get_memoization_map()._map_stats[fully_qualified_function_name] = (
+        MemoizationStats(
+            [time.perf_counter_ns()],
+            [],
+            [],
+            [sys.getsizeof(expected_result)],
+        )
     )
     result = _pipeline_manager.memoized_static_call(
         fully_qualified_function_name,

--- a/tests/safeds_runner/server/test_memoization.py
+++ b/tests/safeds_runner/server/test_memoization.py
@@ -38,17 +38,24 @@ class UnhashableClass:
 
 
 @pytest.mark.parametrize(
-    argnames="function_name,params,hidden_params,expected_result",
+    argnames=(
+        "fully_qualified_function_name",
+        "positional_arguments",
+        "keyword_arguments",
+        "hidden_arguments",
+        "expected_result",
+    ),
     argvalues=[
-        ("function_pure", [1, 2, 3], [], "abc"),
-        ("function_impure_readfile", ["filea.txt"], [1234567891], "abc"),
+        ("function_pure", [1, 2, 3], {}, [], "abc"),
+        ("function_impure_readfile", ["filea.txt"], {}, [1234567891], "abc"),
     ],
     ids=["function_pure", "function_impure_readfile"],
 )
 def test_memoization_static_already_present_values(
-    function_name: str,
-    params: list,
-    hidden_params: list,
+    fully_qualified_function_name: str,
+    positional_arguments: list,
+    keyword_arguments: dict,
+    hidden_arguments: list,
     expected_result: Any,
 ) -> None:
     _pipeline_manager.current_pipeline = PipelineProcess(
@@ -60,36 +67,50 @@ def test_memoization_static_already_present_values(
     )
     _pipeline_manager.current_pipeline.get_memoization_map()._map_values[
         (
-            function_name,
-            _make_hashable(params),
-            _make_hashable(hidden_params),
+            fully_qualified_function_name,
+            _make_hashable(positional_arguments),
+            _make_hashable(hidden_arguments),
         )
     ] = expected_result
-    _pipeline_manager.current_pipeline.get_memoization_map()._map_stats[function_name] = MemoizationStats(
+    _pipeline_manager.current_pipeline.get_memoization_map()._map_stats[fully_qualified_function_name] = MemoizationStats(
         [time.perf_counter_ns()],
         [],
         [],
         [sys.getsizeof(expected_result)],
     )
-    result = _pipeline_manager.memoized_static_call(function_name, lambda *_: None, params, hidden_params)
+    result = _pipeline_manager.memoized_static_call(
+        fully_qualified_function_name,
+        lambda *_: None,
+        positional_arguments,
+        keyword_arguments,
+        hidden_arguments,
+    )
     assert result == expected_result
 
 
 @pytest.mark.parametrize(
-    argnames="function_name,function,params,hidden_params,expected_result",
+    argnames=(
+        "fully_qualified_function_name",
+        "callable_",
+        "positional_arguments",
+        "keyword_arguments",
+        "hidden_arguments",
+        "expected_result",
+    ),
     argvalues=[
-        ("function_pure", lambda a, b, c: a + b + c, [1, 2, 3], [], 6),
-        ("function_impure_readfile", lambda filename: filename.split(".")[0], ["abc.txt"], [1234567891], "abc"),
-        ("function_dict", lambda x: len(x), [{}], [], 0),
-        ("function_lambda", lambda x: x(), [lambda: 0], [], 0),
+        ("function_pure", lambda a, b, c: a + b + c, [1, 2, 3], {}, [], 6),
+        ("function_impure_readfile", lambda filename: filename.split(".")[0], ["abc.txt"], {}, [1234567891], "abc"),
+        ("function_dict", lambda x: len(x), [{}], {}, [], 0),
+        ("function_lambda", lambda x: x(), [lambda: 0], {}, [], 0),
     ],
     ids=["function_pure", "function_impure_readfile", "function_dict", "function_lambda"],
 )
 def test_memoization_static_not_present_values(
-    function_name: str,
-    function: typing.Callable,
-    params: list,
-    hidden_params: list,
+    fully_qualified_function_name: str,
+    callable_: typing.Callable,
+    positional_arguments: list,
+    keyword_arguments: dict,
+    hidden_arguments: list,
     expected_result: Any,
 ) -> None:
     _pipeline_manager.current_pipeline = PipelineProcess(
@@ -100,10 +121,23 @@ def test_memoization_static_not_present_values(
         MemoizationMap({}, {}),
     )
     # Save value in map
-    result = memoized_static_call(function_name, function, params, hidden_params)
+    result = memoized_static_call(
+        fully_qualified_function_name,
+        callable_,
+        positional_arguments,
+        keyword_arguments,
+        hidden_arguments,
+    )
     assert result == expected_result
+
     # Test if value is actually saved by calling another function that does not return the expected result
-    result2 = memoized_static_call(function_name, lambda *_: None, params, hidden_params)
+    result2 = memoized_static_call(
+        fully_qualified_function_name,
+        lambda *_: None,
+        positional_arguments,
+        keyword_arguments,
+        hidden_arguments,
+    )
     assert result2 == expected_result
 
 
@@ -114,7 +148,7 @@ class BaseClass:
     def method1(self) -> int:
         return 1
 
-    def method2(self, default: int = 5) -> int:
+    def method2(self, *, default: int = 5) -> int:
         return 1 * default
 
 
@@ -125,25 +159,36 @@ class ChildClass(BaseClass):
     def method1(self) -> int:
         return 2
 
-    def method2(self, default: int = 3) -> int:
+    def method2(self, *, default: int = 3) -> int:
         return 2 * default
 
 
 @pytest.mark.parametrize(
-    argnames="function_name,function,params,hidden_params,expected_result",
-    argvalues=[
-        ("method1", None, [BaseClass()], [], 1),
-        ("method1", None, [ChildClass()], [], 2),
-        ("method2", lambda instance, *_: instance.method2(default=7), [BaseClass(), 7], [], 7),
-        ("method2", lambda instance, *_: instance.method2(default=7), [ChildClass(), 7], [], 14),
+    argnames=[
+        "receiver",
+        "function_name",
+        "positional_arguments",
+        "keyword_arguments",
+        "hidden_arguments",
+        "expected_result",
     ],
-    ids=["member_call_base", "member_call_child", "member_call_base_lambda", "member_call_child_lambda"],
+    argvalues=[
+        (BaseClass(), "method1", [], {}, [], 1),
+        (ChildClass(), "method1", [], {}, [], 2),
+        (BaseClass(), "method2", [], {"default": 5}, [], 5),
+    ],
+    ids=[
+        "member_call_base",
+        "member_call_child",
+        "member_call_keyword_only_argument",
+    ],
 )
 def test_memoization_dynamic(
+    receiver: Any,
     function_name: str,
-    function: typing.Callable | None,
-    params: list,
-    hidden_params: list,
+    positional_arguments: list,
+    keyword_arguments: dict,
+    hidden_arguments: list,
     expected_result: Any,
 ) -> None:
     _pipeline_manager.current_pipeline = PipelineProcess(
@@ -153,41 +198,52 @@ def test_memoization_dynamic(
         {},
         MemoizationMap({}, {}),
     )
+
     # Save value in map
-    result = memoized_dynamic_call(function_name, function, params, hidden_params)
+    result = memoized_dynamic_call(
+        receiver,
+        function_name,
+        positional_arguments,
+        keyword_arguments,
+        hidden_arguments,
+    )
     assert result == expected_result
+
     # Test if value is actually saved by calling another function that does not return the expected result
-    result2 = memoized_dynamic_call(function_name, lambda *_: None, params, hidden_params)
+    result2 = memoized_dynamic_call(
+        receiver,
+        function_name,
+        positional_arguments,
+        keyword_arguments,
+        hidden_arguments,
+    )
     assert result2 == expected_result
 
 
 @pytest.mark.parametrize(
-    argnames="function_name,function,params,hidden_params,fully_qualified_function_name",
+    argnames=(
+        "receiver",
+        "function_name",
+        "positional_arguments",
+        "keyword_arguments",
+        "hidden_arguments",
+        "fully_qualified_function_name",
+    ),
     argvalues=[
-        ("method1", None, [BaseClass()], [], "tests.safeds_runner.server.test_memoization.BaseClass.method1"),
-        ("method1", None, [ChildClass()], [], "tests.safeds_runner.server.test_memoization.ChildClass.method1"),
-        (
-            "method2",
-            lambda instance, *_: instance.method2(default=7),
-            [BaseClass(), 7],
-            [],
-            "tests.safeds_runner.server.test_memoization.BaseClass.method2",
-        ),
-        (
-            "method2",
-            lambda instance, *_: instance.method2(default=7),
-            [ChildClass(), 7],
-            [],
-            "tests.safeds_runner.server.test_memoization.ChildClass.method2",
-        ),
+        (BaseClass(), "method1", [], {}, [], "tests.safeds_runner.server.test_memoization.BaseClass.method1"),
+        (ChildClass(), "method1", [], {}, [], "tests.safeds_runner.server.test_memoization.ChildClass.method1"),
     ],
-    ids=["member_call_base", "member_call_child", "member_call_base_lambda", "member_call_child_lambda"],
+    ids=[
+        "member_call_base",
+        "member_call_child",
+    ],
 )
 def test_memoization_dynamic_contains_correct_fully_qualified_name(
+    receiver: Any,
     function_name: str,
-    function: typing.Callable | None,
-    params: list,
-    hidden_params: list,
+    positional_arguments: list,
+    keyword_arguments: dict,
+    hidden_arguments: list,
     fully_qualified_function_name: Any,
 ) -> None:
     _pipeline_manager.current_pipeline = PipelineProcess(
@@ -198,31 +254,48 @@ def test_memoization_dynamic_contains_correct_fully_qualified_name(
         MemoizationMap({}, {}),
     )
     # Save value in map
-    result = memoized_dynamic_call(function_name, function, params, hidden_params)
+    result = memoized_dynamic_call(
+        receiver,
+        function_name,
+        positional_arguments,
+        keyword_arguments,
+        hidden_arguments,
+    )
+
     # Test if value is actually saved with the correct function name
-    result2 = memoized_static_call(fully_qualified_function_name, lambda *_: None, params, hidden_params)
+    result2 = memoized_static_call(
+        fully_qualified_function_name,
+        lambda *_: None,
+        [receiver, *positional_arguments],
+        keyword_arguments,
+        hidden_arguments,
+    )
+
     assert result == result2
 
 
 @pytest.mark.parametrize(
-    argnames="function_name,function,params,hidden_params,fully_qualified_function_name",
+    argnames=(
+        "receiver",
+        "function_name",
+        "positional_arguments",
+        "keyword_arguments",
+        "hidden_arguments",
+        "fully_qualified_function_name",
+    ),
     argvalues=[
-        ("method1", None, [ChildClass()], [], "tests.safeds_runner.server.test_memoization.BaseClass.method1"),
-        (
-            "method2",
-            lambda instance, *_: instance.method2(default=7),
-            [ChildClass(), 7],
-            [],
-            "tests.safeds_runner.server.test_memoization.BaseClass.method2",
-        ),
+        (ChildClass(), "method1", [], {}, [], "tests.safeds_runner.server.test_memoization.BaseClass.method1"),
     ],
-    ids=["member_call_child", "member_call_child_lambda"],
+    ids=[
+        "member_call_child",
+    ],
 )
 def test_memoization_dynamic_not_base_name(
+    receiver: Any,
     function_name: str,
-    function: typing.Callable | None,
-    params: list,
-    hidden_params: list,
+    positional_arguments: list,
+    keyword_arguments: dict,
+    hidden_arguments: list,
     fully_qualified_function_name: Any,
 ) -> None:
     _pipeline_manager.current_pipeline = PipelineProcess(
@@ -232,27 +305,54 @@ def test_memoization_dynamic_not_base_name(
         {},
         MemoizationMap({}, {}),
     )
+
     # Save value in map
-    result = memoized_dynamic_call(function_name, function, params, hidden_params)
+    result = memoized_dynamic_call(
+        receiver,
+        function_name,
+        positional_arguments,
+        keyword_arguments,
+        hidden_arguments,
+    )
+
     # Test if value is actually saved with the correct function name
-    result2 = memoized_static_call(fully_qualified_function_name, lambda *_: None, params, hidden_params)
+    result2 = memoized_static_call(
+        fully_qualified_function_name,
+        lambda *_: None,
+        [receiver, *positional_arguments],
+        keyword_arguments,
+        hidden_arguments,
+    )
     assert result is not None
     assert result2 is None
 
 
 @pytest.mark.parametrize(
-    argnames="function_name,function,params,hidden_params,expected_result",
+    argnames=(
+        "fully_qualified_function_name",
+        "callable_",
+        "positional_arguments",
+        "keyword_arguments",
+        "hidden_arguments",
+        "expected_result",
+    ),
     argvalues=[
-        ("unhashable_params", lambda a: type(a).__name__, [UnhashableClass()], [], "UnhashableClass"),
-        ("unhashable_hidden_params", lambda: None, [], [UnhashableClass()], None),
+        ("unhashable_positional_argument", lambda a: type(a).__name__, [UnhashableClass()], {}, [], "UnhashableClass"),
+        ("unhashable_params", lambda a: type(a).__name__, [UnhashableClass()], {}, [], "UnhashableClass"),
+        ("unhashable_hidden_params", lambda: None, [], {}, [UnhashableClass()], None),
     ],
-    ids=["unhashable_params", "unhashable_hidden_params"],
+    ids=[
+        "unhashable_positional_argument",
+        "unhashable_keyword_argument",
+        "unhashable_hidden_arguments",
+    ],
 )
 def test_memoization_static_unhashable_values(
-    function_name: str,
-    function: typing.Callable,
-    params: list,
-    hidden_params: list,
+    fully_qualified_function_name: str,
+    callable_: typing.Callable,
+    positional_arguments: list,
+    keyword_arguments: dict,
+    hidden_arguments: list,
     expected_result: Any,
 ) -> None:
     _pipeline_manager.current_pipeline = PipelineProcess(
@@ -262,7 +362,13 @@ def test_memoization_static_unhashable_values(
         {},
         MemoizationMap({}, {}),
     )
-    result = memoized_static_call(function_name, function, params, hidden_params)
+    result = memoized_static_call(
+        fully_qualified_function_name,
+        callable_,
+        positional_arguments,
+        keyword_arguments,
+        hidden_arguments,
+    )
     assert result == expected_result
 
 
@@ -435,20 +541,33 @@ def test_memoization_map_remove_worst_element_strategy(
 
 
 @pytest.mark.parametrize(
-    argnames="function_name,function,params,hidden_params,expected_result",
+    argnames=(
+        "fully_qualified_function_name",
+        "callable_",
+        "positional_arguments",
+        "keyword_arguments",
+        "hidden_arguments",
+        "expected_result",
+    ),
     argvalues=[
-        ("function_pure", lambda a, b, c: a + b + c, [1, 2, 3], [], 6),
-        ("function_impure_readfile", lambda filename: filename.split(".")[0], ["abc.txt"], [1234567891], "abc"),
-        ("function_dict", lambda x: len(x), [{}], [], 0),
-        ("function_lambda", lambda x: x(), [lambda: 0], [], 0),
+        ("function_pure", lambda a, b, c: a + b + c, [1, 2, 3], {}, [], 6),
+        ("function_impure_readfile", lambda filename: filename.split(".")[0], ["abc.txt"], {}, [1234567891], "abc"),
+        ("function_dict", lambda x: len(x), [{}], {}, [], 0),
+        ("function_lambda", lambda x: x(), [lambda: 0], {}, [], 0),
     ],
-    ids=["function_pure", "function_impure_readfile", "function_dict", "function_lambda"],
+    ids=[
+        "function_pure",
+        "function_impure_readfile",
+        "function_dict",
+        "function_lambda",
+    ],
 )
 def test_memoization_limited_static_not_present_values(
-    function_name: str,
-    function: typing.Callable,
-    params: list,
-    hidden_params: list,
+    fully_qualified_function_name: str,
+    callable_: typing.Callable,
+    positional_arguments: list,
+    keyword_arguments: dict,
+    hidden_arguments: list,
     expected_result: Any,
 ) -> None:
     memo_map = MemoizationMap(
@@ -464,9 +583,23 @@ def test_memoization_limited_static_not_present_values(
         memo_map,
     )
     # Save value in map
-    result = memoized_static_call(function_name, function, params, hidden_params)
+    result = memoized_static_call(
+        fully_qualified_function_name,
+        callable_,
+        positional_arguments,
+        keyword_arguments,
+        hidden_arguments,
+    )
     assert result == expected_result
+
     # Test if value is actually saved by calling another function that does not return the expected result
-    result2 = memoized_static_call(function_name, lambda *_: None, params, hidden_params)
+    result2 = memoized_static_call(
+        fully_qualified_function_name,
+        lambda *_: None,
+        positional_arguments,
+        keyword_arguments,
+        hidden_arguments,
+    )
+
     assert result2 == expected_result
     assert len(memo_map._map_values.items()) < 3

--- a/tests/safeds_runner/server/test_websocket_mock.py
+++ b/tests/safeds_runner/server/test_websocket_mock.py
@@ -353,9 +353,9 @@ async def test_should_execute_pipeline_return_exception(
                                         " value1)\n\tsafeds_runner.save_placeholder('obj',"
                                         " object())\n\tsafeds_runner.save_placeholder('image',"
                                         " Image.from_bytes(base64.b64decode('iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAD0lEQVQIW2NkQAOMpAsAAADuAAVDMQ2mAAAAAElFTkSuQmCC')))\n\t"
-                                        "table = safeds_runner.memoized_static_call(\"safeds.data.tabular.containers.Table.from_dict\", Table.from_dict, [{'a': [1, 2], 'b': [3, 4]}], [])\n\t"
+                                        "table = safeds_runner.memoized_static_call(\"safeds.data.tabular.containers.Table.from_dict\", Table.from_dict, [{'a': [1, 2], 'b': [3, 4]}], {}, [])\n\t"
                                         "safeds_runner.save_placeholder('table',table)\n\t"
-                                        'object_mem = safeds_runner.memoized_static_call("random.object.call", SafeDsEncoder, [], [])\n\t'
+                                        'object_mem = safeds_runner.memoized_static_call("random.object.call", SafeDsEncoder, [], {}, [])\n\t'
                                         "safeds_runner.save_placeholder('object_mem',object_mem)\n"
                                     ),
                                     "gen_test_a_pipe": (


### PR DESCRIPTION
Related to https://github.com/Safe-DS/DSL/issues/1087

### Summary of Changes

Memoized calls now accept positional and keyword arguments separately.
