### PR TITLE
ci: exclude two matrix configurations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,11 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
+        exclude:
+          - platform: "macos-latest"
+            python-version: "3.11"
+          - platform: "windows-latest"
+            python-version: "3.11"
     uses: lars-reimann/.github/.github/workflows/poetry-codecov-reusable.yml@main
     with:
       working-directory: .

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,11 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
+        exclude:
+          - platform: "macos-latest"
+            python-version: "3.11"
+          - platform: "windows-latest"
+            python-version: "3.11"
     uses: lars-reimann/.github/.github/workflows/poetry-codecov-reusable.yml@main
     with:
       working-directory: .


### PR DESCRIPTION
### Summary of Changes

Don't run tests on Windows/MacOS and Python 3.11 to not overload the cache.