### PR TITLE
fix: encoding of non-finite floats

### DIFF
--- a/src/safeds_runner/server/_json_encoder.py
+++ b/src/safeds_runner/server/_json_encoder.py
@@ -55,3 +55,9 @@ class SafeDsEncoder(json.JSONEncoder):
             }
         else:
             return super().default(o)
+
+    def encode(self, o: Any) -> str:
+        if isinstance(o, float) and not math.isfinite(o):
+            return f'"{o!s}"'
+        else:
+            return super().encode(o)

--- a/tests/safeds_runner/server/test_json_encoder.py
+++ b/tests/safeds_runner/server/test_json_encoder.py
@@ -38,8 +38,11 @@ from safeds_runner.server._json_encoder import SafeDsEncoder
                 '"iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAADElEQVR4nGNgoBwAAABEAAHX40j9\\nAAAAAElFTkSuQmCC\\n"}'
             ),
         ),
+        (math.nan, '"nan"'),
+        (math.inf, '"inf"'),
+        (-math.inf, '"-inf"'),
     ],
-    ids=["encode_tabular_dataset", "encode_table", "encode_image_png"],
+    ids=["encode_tabular_dataset", "encode_table", "encode_image_png", "nan", "inf", "-inf"],
 )
 def test_encoding_custom_types(data: Any, expected_string: str) -> None:
     assert json.dumps(data, cls=SafeDsEncoder) == expected_string

--- a/tests/safeds_runner/server/test_websocket_mock.py
+++ b/tests/safeds_runner/server/test_websocket_mock.py
@@ -554,12 +554,12 @@ async def test_should_execute_pipeline_return_exception(
                     create_placeholder_value(
                         QueryMessageData(name="col"),
                         "Column",
-                        '+------+\n'
-                              '| a    |\n'
-                              '| ---  |\n'
-                              '| null |\n'
-                              '+======+\n'
-                              '+------+'
+                        "+------+\n"
+                              "| a    |\n"
+                              "| ---  |\n"
+                              "| null |\n"
+                              "+======+\n"
+                              "+------+",
                     ),
                 ),
                 # Query Result Invalid


### PR DESCRIPTION
### Summary of Changes

By default, the `dumps` method of Python's `json` module generates invalid JSON for non-finite floats (NaN, +/- Infinity). We now convert them to a string instead. For tables, we still replace them with nulls as before to avoid mixed data.

If we later use a binary format to transfer the table data, we won't need to replace these values in tables anymore.